### PR TITLE
chore: allow no result of json path

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -211,7 +211,7 @@ where
         "$".to_string()
     };
     match jsonpath_lib::select(&resource_json, &from_field_path)?.as_slice() {
-        [] => Err(Error::JsonPathNoValues(from_field_path.to_owned())),
+        [] => Ok(json!(null)),
         [subtree] => Ok((*subtree).clone()),
         _ => Err(Error::JsonPathExactlyOneValue(from_field_path.to_owned())),
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Error {
     #[error(transparent)]
     AddToPathError(#[from] mapping::AddToPathError),
 
-    #[error("JSONPath '{0}' didn't produce exactly one value")]
+    #[error("JSONPath '{0}' propduced no values")]
     JsonPathNoValues(String),
 
     #[error("JSONPath '{0}' didn't produce exactly one value")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ pub enum Error {
     #[error(transparent)]
     AddToPathError(#[from] mapping::AddToPathError),
 
-    #[error("JSONPath '{0}' propduced no values")]
+    #[error("JSONPath '{0}' produced no values")]
     JsonPathNoValues(String),
 
     #[error("JSONPath '{0}' didn't produce exactly one value")]


### PR DESCRIPTION
i have a case in our running cluster where i tell the sinker to copy metadata.labels and the source resources doesn't have it. it fails to reconcile the sync at all.

seems to me that should be allowed. wdyt?

i ran this locally, pointing at CST, and it ceased to error on that sync and it applied the rest of the mappings.