### PR TITLE
fix: Skip GHR auth in PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: ["main"]   
+    branches: ["main"]
   pull_request:
     branches: ["main"]
 
@@ -38,8 +38,9 @@ jobs:
           registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
+        if: github.event_name != 'pull_request'
 
-      - run: |  
+      - run: |
           echo "LAST_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Build


### PR DESCRIPTION
The CI jobs we run as part of the PR builds do not push images to the GHR registry but currently they perform the login action.

This action doesn't work if the originator of the PR is dependabot:

<img width="995" alt="image" src="https://github.com/influxdata/sinker/assets/52673/4e16df3d-02d6-4a01-b570-f5616a49eec2">

Since we're skipping the push we can also skip the auth step