### PR TITLE
chore: allow empty mapping string

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -239,7 +239,11 @@ where
 {
     let resource_json = serde_json::to_value(&resource)?;
     let from_field_path = if let Some(from_field_path) = from_field_path {
-        format!("$.{}", from_field_path)
+        if from_field_path.len() == 0 {
+            "$".to_string()
+        } else {
+            format!("$.{}", from_field_path)
+        }
     } else {
         "$".to_string()
     };


### PR DESCRIPTION
it should be possible to specify an empty string as a mapping, e.g. let's say you want to copy some subtree of an object into the root of another, or vise versa. the to and from mapping fields are both required so we must support an empty string to indicate this case. as the code was before it would become the jsonpath `$.` because we were simply checking if the option was Some(String).