### PR TITLE
chore: Upgrade to kube-rs 0.83.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,9 +813,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
+checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
 dependencies = [
  "serde",
  "serde_json",
@@ -836,11 +836,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1985030683a2bac402cbda61222195de80d3f66b4c87ab56e5fea379bd98c3"
+checksum = "cd990069640f9db34b3b0f7a1afc62a05ffaa3be9b66aa3c313f58346df7f788"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "bytes",
  "chrono",
  "http",
@@ -853,22 +853,22 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.80.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414d80c69906a91e8ecf4ae16d0fb504e19aa6b099135d35d85298b4e4be3ed3"
+checksum = "32f468b2fa6c5ef92117813238758f79e394c2d7688bd6faa3e77243f90260b0"
 dependencies = [
  "k8s-openapi",
  "kube-client",
  "kube-core",
- "kube-derive 0.80.0",
+ "kube-derive 0.83.0",
  "kube-runtime",
 ]
 
 [[package]]
 name = "kube-client"
-version = "0.80.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dc5ae0b9148b4e2ebb0dabda06a0cd65b1eed2f41d792d49787841a68050283"
+checksum = "337eb332d253036adc3247936248d0742c6c743f51eb38a684fd9b3b2878b27c"
 dependencies = [
  "base64 0.20.0",
  "bytes",
@@ -890,7 +890,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tokio-util",
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.80.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98331c6f1354893f7c50da069e43a3fd1c84e55bbedc7765d9db22ec3291d07d"
+checksum = "f924177ad71936cfe612641b45bb9879890696d3c026f0846423529f4fa449af"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.80.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4be6ff26b9a34ce831d341e8b33bc78986a33c1be88f5bf9ca84e92e98b1dfb"
+checksum = "3ce7c7a14cf3fe567ca856de41db0d61394867675cfb0d65094c55f0fa2df2e0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -945,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.80.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b698eb8998b46683b0dc3c2ce72c80bc308fc8159f25afa719668c290a037a57"
+checksum = "6d5e4d09df25250ffcb09df3f31105a5f49eb8f8a08da9b776ea5b6431ec476f"
 dependencies = [
  "ahash",
  "async-trait",
@@ -970,9 +970,8 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec5a7c0731d6e668936f6723d4e8dbe4789ad16f5026b37dbb4cc1100a31728"
+version = "0.15.0"
+source = "git+https://github.com/hawkw/kubert?rev=1c44765207c78aadb30b39138b2ee8d8c9ffa2c9#1c44765207c78aadb30b39138b2ee8d8c9ffa2c9"
 dependencies = [
  "ahash",
  "clap",
@@ -1069,6 +1068,12 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -1568,18 +1573,6 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.2",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
@@ -1625,7 +1618,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml 0.9.25",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tracing",
@@ -1842,18 +1835,19 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
 dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
+ "base64 0.21.0",
+ "bitflags 2.3.3",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-range-header",
+ "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -2288,15 +2282,6 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ description = "Copy k8s resources (or parts thereof) across clusters"
 [dependencies]
 clap = { version = "4.3", features = ["derive", "help", "env", "std"] }
 futures = "0.3"
-kube = { version = "0.80.0", features = ["runtime", "derive"] }
+kube = { version = "0.83.0", features = ["runtime", "derive"] }
 kube-derive = "0.84.0"
-k8s-openapi = { version = "0.17.0", features = ["v1_26"] }
-kubert = { version = "0.16.1", features = ["clap", "runtime", "server"] }
+k8s-openapi = { version = "0.18.0", features = ["v1_26"] }
+# We cannot bump kube-res past 0.82.0 until this PR is merged: https://github.com/olix0r/kubert/pull/163
+# until then we can use this fork (mkm reviewed it and pinned the commit)
+kubert = { git = "https://github.com/hawkw/kubert", features = ["clap", "runtime", "server"], rev="1c44765207c78aadb30b39138b2ee8d8c9ffa2c9" }
+# kubert = { version = "0.16.1", features = ["clap", "runtime", "server"] }
 tokio = { version = "1.26", features = ["full"] }
 anyhow = { version = "1", features = ["backtrace"] }
 tracing = "0.1"

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -6,7 +6,10 @@ use kube::{
     api::{ListParams, Patch, PatchParams},
     core::{DynamicObject, GroupVersionKind, ObjectMeta},
     discovery::{self, ApiResource},
-    runtime::controller::{Action, Controller},
+    runtime::{
+        controller::{Action, Controller},
+        watcher,
+    },
     Api, Client, Config, Resource, ResourceExt,
 };
 use serde_json::json;
@@ -321,7 +324,7 @@ pub async fn run(client: Client) -> Result<()> {
         error!("CRD is not queryable; {e:?}. Is the CRD installed?");
         std::process::exit(1);
     }
-    Controller::new(docs, ListParams::default())
+    Controller::new(docs, watcher::Config::default().any_semantic())
         .shutdown_on_signal()
         .run(reconcile, error_policy, Arc::new(Context { client }))
         .filter_map(|x| async move { std::result::Result::ok(x) })


### PR DESCRIPTION
The kubert project is have a bit of a moment with the PR queue. I'll re-evaluate if it's a project we can rely on; in the meantime let's depend on a PR.