### PR TITLE
chore: Use serde_json_path library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "inventory"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0508c56cfe9bfd5dfeb0c22ab9a6abfda2f27bdca422132e494266351ed8d83c"
+
+[[package]]
 name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1100,16 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1323,6 +1354,8 @@ version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1594,6 +1627,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_path"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c79e076e7e0e91510241afe3c432cb8b5126245153f7141077ffb074d270eb"
+dependencies = [
+ "inventory",
+ "nom",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_json_path_core",
+ "serde_json_path_macros",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_json_path_core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e774ec1b58d942c47f7abbdc30ba876e5525590c5388760185b1fbe283f9f10c"
+dependencies = [
+ "inventory",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "serde_json_path_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d2a13b43f935dd6864d91d2ea2426624bb9f3c7263d943b31f449ffc4fb7"
+dependencies = [
+ "inventory",
+ "once_cell",
+ "serde_json_path_core",
+ "serde_json_path_macros_internal",
+]
+
+[[package]]
+name = "serde_json_path_macros_internal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb9387330da43020c17237e22c76bd19c93305c75d99ec962c58f385c7e1f5ad"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,7 +1717,6 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
- "jsonpath_lib",
  "k8s-openapi",
  "kube",
  "kube-derive 0.84.0",
@@ -1640,6 +1725,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_json_path",
  "serde_yaml",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,12 @@ futures = "0.3"
 kube = { version = "0.85.0", features = ["runtime", "derive"] }
 kube-derive = "0.84.0"
 k8s-openapi = { version = "0.19.0", features = ["v1_26"] }
-kubert = { version = "0.19.0", features = ["clap", "runtime", "server", "rustls-tls"] }
+kubert = { version = "0.19.0", features = [
+    "clap",
+    "runtime",
+    "server",
+    "rustls-tls",
+] }
 tokio = { version = "1.26", features = ["full"] }
 anyhow = { version = "1", features = ["backtrace"] }
 tracing = "0.1"
@@ -22,8 +27,8 @@ schemars = "0.8.15"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9.25"
-jsonpath_lib = "0.3.0"
 thiserror = "1"
+serde_json_path = "0.6.3"
 
 [dev-dependencies]
 rstest = "0.17.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub enum Error {
     SerializationError(#[from] serde_json::Error),
 
     #[error("JsonPathError: {0}")]
-    JsonPathError(#[from] jsonpath_lib::JsonPathError),
+    JsonPathError(#[from] serde_json_path::ParseError),
 
     #[error("Namespace is required")]
     NamespaceRequired,


### PR DESCRIPTION
Switch to the [serde_json_path](https://crates.io/crates/serde_json_path) crate which implements JSONPath as stardardized by the ([IETF JSONPath Specification](https://www.ietf.org/archive/id/draft-ietf-jsonpath-base-20.html).

(I have vested interest in using that specification since I invested some time in bootstrapping the group, but I have no affiliation with the rust implementation)