### PR TITLE
fix(container image): fix ssl3 runtime dep, update to debian 12 bookworm, upgrade rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
-FROM lukemathwalker/cargo-chef:latest-rust-1.74-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.74-bookworm@sha256:f2be0d7e17e30166653ccc67498e82759d8124ed8770b48f06395caa8e95c97f AS chef
 WORKDIR app
 
 FROM chef AS planner
@@ -16,7 +16,7 @@ COPY . .
 RUN cargo build --release --bin sinker
 
 # We do not need the Rust toolchain to run the binary!
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:f80c45482c8d147da87613cb6878a7238b8642bcc24fc11bad78c7bec726f340
 
 RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
-FROM lukemathwalker/cargo-chef:latest-rust-1.74-bookworm@sha256:f2f6e652c5aa759f9ff6b1f97062da912babc9c92641156c0c1723690448d384 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.74-bookworm AS chef
 WORKDIR app
 
 FROM chef AS planner
@@ -16,7 +16,7 @@ COPY . .
 RUN cargo build --release --bin sinker
 
 # We do not need the Rust toolchain to run the binary!
-FROM debian:bookworm-slim@sha256:45287d89d96414e57c7705aa30cb8f9836ef30ae8897440dd8f06c4cff801eec
+FROM debian:bookworm-slim
 
 RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Leveraging the pre-built Docker images with
 # cargo-chef and the Rust toolchain
-FROM lukemathwalker/cargo-chef:latest-rust-1.73.0@sha256:09ec7a922dc592d980f3fcfa97b873e1a678ad2fb252671569a65187f1cd4a75 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.74-bookworm@sha256:f2f6e652c5aa759f9ff6b1f97062da912babc9c92641156c0c1723690448d384 AS chef
 WORKDIR app
 
 FROM chef AS planner
@@ -16,7 +16,16 @@ COPY . .
 RUN cargo build --release --bin sinker
 
 # We do not need the Rust toolchain to run the binary!
-FROM debian:bookworm-slim@sha256:45287d89d96414e57c7705aa30cb8f9836ef30ae8897440dd8f06c4cff801eec AS runtime
+FROM debian:bookworm-slim@sha256:45287d89d96414e57c7705aa30cb8f9836ef30ae8897440dd8f06c4cff801eec
+
+RUN apt update \
+    && apt install --yes ca-certificates libssl3 --no-install-recommends \
+    && rm -rf /var/lib/{apt,dpkg,cache,log} \
+    && groupadd --gid 1500 sinker \
+    && useradd --uid 1500 --gid sinker --shell /bin/bash --create-home sinker
+
+USER sinker
+
 WORKDIR app
 COPY --from=builder /app/target/release/sinker /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/sinker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 RUN cargo build --release --bin sinker
 
 # We do not need the Rust toolchain to run the binary!
-FROM debian:bullseye-slim@sha256:77f46c1cf862290e750e913defffb2828c889d291a93bdd10a7a0597720948fc AS runtime
+FROM debian:bookworm-slim@sha256:45287d89d96414e57c7705aa30cb8f9836ef30ae8897440dd8f06c4cff801eec AS runtime
 WORKDIR app
 COPY --from=builder /app/target/release/sinker /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/sinker"]


### PR DESCRIPTION
Sinker got ssl security updates that requires libssl.so.3 which debian bullseye doesn't have. So sinker pods can't run. To resolve, i upgraded to bookworm images, upgraded rust to 1.74, copied over what the iox dockerfile does to bring in the libssl3 libraries, added a sinker user (also following iox's dockerfile). 

`apt install libssl3` was the critical piece. 


The new runtime container image is 122MB. The previous image is 94MB.

pod error 
```
/usr/local/bin/sinker: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```

* https://github.com/influxdata/sinker/pull/107 - security update
* https://github.com/influxdata/k8s-idpe/pull/35737 - manual sinker release
* [slack notice](https://influxdata.slack.com/archives/C04C3U2HJCQ/p1703283852235279)


I believe this works although proving it on my M2 Max is difficult. 