### PR TITLE
chore: rebuild sinker to address jan-2024 glibc updates for debian bookworm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,4 +70,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: us-docker.pkg.dev/influxdb2-artifacts/tubernetes/sinker:${{ env.LAST_COMMIT_SHA }}
-        if: github.event_name != 'pull_request'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,4 +68,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: us-docker.pkg.dev/influxdb2-artifacts/tubernetes/sinker:${{ env.LAST_COMMIT_SHA }}
-        if: github.event_name != 'pull_request'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,6 @@ jobs:
           registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
-        if: github.event_name != 'pull_request'
 
       - run: |
           echo "LAST_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
@@ -60,7 +59,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: us-docker.pkg.dev/influxdb2-artifacts/tubernetes/sinker:${{ env.LAST_COMMIT_SHA }}
-        if: github.event_name == 'pull_request'
 
       - name: Build & Push
         uses: depot/build-push-action@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,7 +47,6 @@ jobs:
           registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
-        if: github.event_name != 'pull_request'
 
       - run: |
           echo "LAST_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,7 @@ jobs:
           registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
+        if: github.event_name != 'pull_request'
 
       - run: |
           echo "LAST_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
@@ -69,3 +70,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: us-docker.pkg.dev/influxdb2-artifacts/tubernetes/sinker:${{ env.LAST_COMMIT_SHA }}
+        if: github.event_name != 'pull_request'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -47,6 +47,7 @@ jobs:
           registry: us-docker.pkg.dev
           username: _json_key
           password: ${{ secrets.GAR_JSON_KEY }}
+        if: github.event_name != 'pull_request'
 
       - run: |
           echo "LAST_COMMIT_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
@@ -59,6 +60,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: us-docker.pkg.dev/influxdb2-artifacts/tubernetes/sinker:${{ env.LAST_COMMIT_SHA }}
+        if: github.event_name == 'pull_request'
 
       - name: Build & Push
         uses: depot/build-push-action@v1
@@ -68,3 +70,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: us-docker.pkg.dev/influxdb2-artifacts/tubernetes/sinker:${{ env.LAST_COMMIT_SHA }}
+        if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,13 @@ RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
-# Remove setuid/setgid bits from executables. Also If the path is /proc, don't descend into it. This effectively excludes /proc from the search.
-RUN find / -path /proc -prune -o -type f \( -perm -4000 -o -perm -2000 \) -exec chmod a-s {} \;
+# Remove setuid/setgid bits from executables as a hardening measure so non-root processes can't escalate.
+RUN find / \( -path /dev -o -path /proc -o -path /sys \) -prune -o -type f \( -perm -4000 -o -perm -2000 \) -exec chmod a-s {} \;
 
 # Create a dedicated user and group for the application
 RUN groupadd --gid 1500 sinker \
     && useradd --uid 1500 --gid sinker --shell /bin/bash --create-home sinker
 
-# RUN apt update \
-#     && apt install --yes ca-certificates libssl3 --no-install-recommends \
-#     && rm -rf /var/lib/{apt,dpkg,cache,log} \
-#     && groupadd --gid 1500 sinker \
-#     && useradd --uid 1500 --gid sinker --shell /bin/bash --create-home sinker
 
 USER sinker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,23 @@ RUN cargo build --release --bin sinker
 # We do not need the Rust toolchain to run the binary!
 FROM debian:bookworm-slim@sha256:f80c45482c8d147da87613cb6878a7238b8642bcc24fc11bad78c7bec726f340
 
+# Update the system and install necessary packages
 RUN apt update \
     && apt install --yes ca-certificates libssl3 --no-install-recommends \
-    && rm -rf /var/lib/{apt,dpkg,cache,log} \
-    && groupadd --gid 1500 sinker \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}
+
+# Remove setuid/setgid bits from executables. Also If the path is /proc, don't descend into it. This effectively excludes /proc from the search.
+RUN find / -path /proc -prune -o -type f \( -perm -4000 -o -perm -2000 \) -exec chmod a-s {} \;
+
+# Create a dedicated user and group for the application
+RUN groupadd --gid 1500 sinker \
     && useradd --uid 1500 --gid sinker --shell /bin/bash --create-home sinker
+
+# RUN apt update \
+#     && apt install --yes ca-certificates libssl3 --no-install-recommends \
+#     && rm -rf /var/lib/{apt,dpkg,cache,log} \
+#     && groupadd --gid 1500 sinker \
+#     && useradd --uid 1500 --gid sinker --shell /bin/bash --create-home sinker
 
 USER sinker
 


### PR DESCRIPTION
related to: https://github.com/influxdata/tubernetes/issues/1567

changes:

rebuild sinker to address jan-2024 glibc updates for debian bookworm

#Remove setuid/setgid bits from executables. Also If the path is `/proc`, don't descend into it. This effectively excludes `/proc` from the search.
`RUN find / -path /proc -prune -o -type f \( -perm -4000 -o -perm -2000 \) -exec chmod a-s {} \;`