### PR TITLE
feat: force-delete

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -222,6 +222,7 @@ async fn reconcile(resource_sync: Arc<ResourceSync>, ctx: Arc<Context>) -> Resul
                     if resource_sync.has_force_delete_option_enabled()
                         && resource_sync.has_been_deleted() =>
                 {
+                    debug!(?name, "force-deleting ResourceSync");
                     return stop_watches_and_remove_resource_sync_finalizers(
                         resource_sync,
                         &name,

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -9,6 +9,20 @@ use kube::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+static FORCE_DELETE_ANNOTATION: &str = "sinker.influxdata.io/force-delete";
+
+impl ResourceSync {
+    pub fn has_force_delete_option_enabled(&self) -> bool {
+        self.metadata
+            .annotations
+            .as_ref()
+            .map(|annotations| annotations[FORCE_DELETE_ANNOTATION].clone())
+            .unwrap_or_default()
+            .parse()
+            .unwrap_or_default()
+    }
+}
+
 #[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
 #[kube(
     group = "sinker.influxdata.io",

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -174,13 +174,13 @@ mod tests {
         ResourceSync{metadata: ObjectMeta{annotations: Some(BTreeMap::new()), ..Default::default()},spec: Default::default(),status: None,}, false
     )]
     #[case::force_delete_annotation_is_false(
-        ResourceSync{metadata: ObjectMeta{annotations: Some(BTreeMap::from([(FORCE_DELETE_ANNOTATION.to_string(), "false".to_string())])), ..Default::default()},spec: Default::default(),status: None,}, false
+        ResourceSync{metadata: ObjectMeta{annotations: Some(BTreeMap::from([(FORCE_DELETE_ANNOTATION.to_string(), false.to_string())])), ..Default::default()},spec: Default::default(),status: None,}, false
     )]
     #[case::force_delete_annotation_is_other(
         ResourceSync{metadata: ObjectMeta{annotations: Some(BTreeMap::from([(FORCE_DELETE_ANNOTATION.to_string(), "other".to_string())])), ..Default::default()},spec: Default::default(),status: None,}, false
     )]
     #[case::force_delete_annotation_is_true(
-        ResourceSync{metadata: ObjectMeta{annotations: Some(BTreeMap::from([(FORCE_DELETE_ANNOTATION.to_string(), "true".to_string())])), ..Default::default()},spec: Default::default(),status: None,}, true
+        ResourceSync{metadata: ObjectMeta{annotations: Some(BTreeMap::from([(FORCE_DELETE_ANNOTATION.to_string(), true.to_string())])), ..Default::default()},spec: Default::default(),status: None,}, true
     )]
     #[tokio::test]
     async fn test_resource_sync_has_force_delete_option_enabled(


### PR DESCRIPTION
Allows the annotation `sinker.influxdata.io/force-delete` to be added to ResourceSyncs. When this annotation is present, Sinker will remove its finalizer from the ResourceSync during deletion without confirming deletion of remote targets if the target cluster is inaccessible.

https://github.com/influxdata/tubernetes/issues/2289