### PR TITLE
chore: clarifying log message

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -139,7 +139,14 @@ async fn reconcile_normally(
 
     let source = source_api
         .get(&resource_sync.spec.source.resource_ref.name)
-        .await?;
+        .await
+        .map_err(|e| {
+            crate::Error::ResourceNotFoundError(
+                resource_sync.spec.source.resource_ref.name.clone(),
+                source_api.ar.kind,
+                e,
+            )
+        })?;
     debug!(?source, "got source object");
 
     let target_ref = &resource_sync.spec.target.resource_ref;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub enum Error {
 
     #[error("Mapping block must contain from_field_path, to_field_path or both, cannot be empty")]
     MappingEmpty,
+
+    #[error("Resource {0} of kind {1} not found: {2}")]
+    ResourceNotFoundError(String, String, kube::Error),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;


### PR DESCRIPTION
i'm seeing lots of log messages like this for sinker:

```
2025-02-21T11:41:10.533585Z  WARN sinker::controller: reconcile failed name="06a8ee86-9e34-4ce7-ae6a-8a9745d3ddab-bvmqn-local-storage-clusterrolebinding-local-path-provisioner-bind" error=Kube Error: ApiError: the server could not find the requested resource: NotFound (ErrorResponse { status: "Failure", message: "the server could not find the requested resource", reason: "NotFound", code: 404 })
```

i suspect it means that it cannot find the source resource, but without knowing which one it's hard to debug. it could be the parent i suppose, but that seems unlikely. the target resource doesn't need to exist so i doubt it would be that.

with this change the log should say "Resource xyz of kind SinkerContainer not found: <existing error message>".