### PR TITLE
feat: skip delete

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -141,7 +141,7 @@ async fn reconcile_normally(
         .get(&resource_sync.spec.source.resource_ref.name)
         .await
         .map_err(|e| {
-            crate::Error::ResourceNotFoundError(
+            Error::ResourceNotFoundError(
                 resource_sync.spec.source.resource_ref.name.clone(),
                 source_api.ar.kind,
                 e,

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -51,6 +51,16 @@ async fn reconcile_deleted_resource(
         return Ok(Action::await_change());
     }
 
+    if resource_sync.has_disable_target_deletion_option_enabled() {
+        return stop_watches_and_remove_resource_sync_finalizers(
+            resource_sync,
+            name,
+            parent_api,
+            ctx,
+        )
+        .await;
+    }
+
     let target_name = &resource_sync.spec.target.resource_ref.name;
 
     match target_api.get(target_name).await {


### PR DESCRIPTION
Enables fix for https://github.com/influxdata/tubernetes/issues/3133 by adding feature to skip target deletion when an annotation is set. Also improves delete logic a bit by auto-selecting between background or foreground delete modes based on whether or not the target has finalizers set.