### PR TITLE
chore: metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ objects and reapplies the desired target when they change.
   Target writes use server-side apply. The repository selects Kubernetes 1.36 API bindings at build time;
   this is not a tested minimum cluster version.
 - `kubectl` with Kustomize support.
+- Prometheus Operator with the `PodMonitor` CRD installed when applying the bundled manifests.
 - The Rust toolchain selected by [rust-toolchain.toml](rust-toolchain.toml), currently `1.98.1`, when building locally.
 - An OCI image builder and a registry accessible to the cluster when building your own container image.
 - For remote clusters, network access from the controller and a usable kubeconfig for each connection.
@@ -44,8 +45,9 @@ The [Dockerfile](Dockerfile) uses cargo-chef for build caching and a distroless 
 
 ### Deploy to Kubernetes
 
-The [bundled manifests](manifests/kustomization.yaml) install both CRDs, a namespace, RBAC, a ServiceAccount, and a
-single-replica Deployment. Customize [deployment.yml](manifests/deployment.yml), directly or through an overlay:
+The [bundled manifests](manifests/kustomization.yaml) install both Sinker CRDs, a namespace, RBAC, a ServiceAccount, a
+single-replica Deployment, and a [PodMonitor](manifests/podmonitor.yml). Customize
+[deployment.yml](manifests/deployment.yml), directly or through an overlay:
 
 - Replace the `sinker:replace_me` image with an image you can pull.
 - Configure the `gar-auth-sinker` image pull Secret, or remove/change `imagePullSecrets` for your registry.
@@ -309,11 +311,14 @@ kubectl -n sinker port-forward deployment/sinker 8080:8080
 # In another terminal:
 curl http://localhost:8080/live
 curl http://localhost:8080/ready
+curl http://localhost:8080/metrics
 ```
 
-The admin server provides `/live` and `/ready`. Readiness reflects runtime initialization and shutdown, not the health
-of individual syncs or remote clusters. **There is currently no registered `/metrics` endpoint**; enabling the dependency's
-Prometheus feature does not configure an exporter in [main.rs](src/main.rs).
+The admin server provides `/live`, `/ready`, and Prometheus metrics at `/metrics` on port `8080`. Readiness reflects
+runtime initialization and shutdown, not the health of individual syncs or remote clusters. The bundled
+[PodMonitor](manifests/podmonitor.yml) selects Sinker pods in its namespace and scrapes `/metrics` through their named
+`admin` port (`8080`). Configure Prometheus's `podMonitorSelector` and `podMonitorNamespaceSelector` to include this
+monitor and its namespace; see the [Prometheus Operator API reference](https://prometheus-operator.dev/docs/api-reference/api/).
 
 Reconciliation errors retry after five seconds; object watches reconnect with backoff. A healthy sync waits for events
 rather than polling on a fixed interval. `ResourceSync` generation filtering tracks name, namespace, and UID, with a

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ objects and reapplies the desired target when they change.
 ### Prerequisites
 
 - A Kubernetes cluster for the controller and its CRDs, with permission to install CRDs, RBAC, and a Deployment.
-  Target writes use server-side apply. The repository selects Kubernetes 1.33 API bindings at build time;
+  Target writes use server-side apply. The repository selects Kubernetes 1.36 API bindings at build time;
   this is not a tested minimum cluster version.
 - `kubectl` with Kustomize support.
 - The Rust toolchain selected by [rust-toolchain.toml](rust-toolchain.toml), currently `1.98.1`, when building locally.

--- a/manifests/crd.yml
+++ b/manifests/crd.yml
@@ -148,6 +148,8 @@ spec:
             - source
             - target
             type: object
+            x-kubernetes-validations:
+            - rule: self == oldSelf
           status:
             nullable: true
             properties:

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - crd.yml
   - deployment.yml
   - namespace.yaml
+  - podmonitor.yml
   - serviceaccount.yml

--- a/manifests/podmonitor.yml
+++ b/manifests/podmonitor.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  labels:
+    app.kubernetes.io/name: sinker
+  name: sinker
+  namespace: sinker
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sinker
+  podMetricsEndpoints:
+    - port: admin
+      path: /metrics

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,14 @@ async fn main() -> anyhow::Result<()> {
             );
         }
         None => {
+            let mut registry = Default::default();
+            let metrics = kubert::runtime::RuntimeMetrics::register(&mut registry);
+
             let rt = kubert::Runtime::builder()
                 .with_log(log_level, log_format)
-                .with_admin(admin)
+                .with_admin(admin.into_builder().with_prometheus(registry))
                 .with_client(client)
+                .with_metrics(metrics)
                 .build()
                 .await?;
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -4,7 +4,7 @@ use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::{
     core::{gvk::ParseGroupVersionError, GroupVersionKind, TypeMeta},
-    CustomResource,
+    CustomResource, KubeSchema,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,7 @@ impl ResourceSync {
     }
 }
 
-#[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, JsonSchema)]
+#[derive(CustomResource, Debug, Serialize, Deserialize, Default, Clone, KubeSchema)]
 #[kube(
     group = "sinker.influxdata.io",
     version = "v1alpha1",
@@ -42,6 +42,7 @@ impl ResourceSync {
 )]
 #[kube(status = "ResourceSyncStatus")]
 #[serde(rename_all = "camelCase")]
+#[x_kube(validation = "self == oldSelf")]
 pub struct ResourceSyncSpec {
     pub source: ClusterResourceRef,
     pub target: ClusterResourceRef,


### PR DESCRIPTION
Enables the metrics server on `/metrics` on the admin port and adds a `PodMonitor` to scrape metrics.

closes https://github.com/influxdata/sinker/issues/170